### PR TITLE
fix: serverMember nickname and roles not updating in cache

### DIFF
--- a/packages/guilded.ts/src/structures/server/ServerMember.ts
+++ b/packages/guilded.ts/src/structures/server/ServerMember.ts
@@ -1,4 +1,4 @@
-import { APIServerMember, APIServerMemberSummary, APISocialLink } from 'guilded-api-typings';
+import { APIServerMember, APIServerMemberSummary, APISocialLink, WSEvents } from 'guilded-api-typings';
 import { Base } from '../Base';
 import { Server } from './Server';
 import { User } from '../User';
@@ -71,6 +71,10 @@ export class ServerMember extends Base {
 	public async setNickname(nickname: string) {
 		await this.server.members.setNickname(this, nickname);
 		return this;
+	}
+
+	public updateCacheNickname(raw: WSEvents["TeamMemberUpdated"]): void {
+		(this.nickname as string | undefined) = 'nickname' in raw.userInfo ? raw.userInfo.nickname : undefined;
 	}
 
 	/**

--- a/packages/guilded.ts/src/structures/server/ServerMember.ts
+++ b/packages/guilded.ts/src/structures/server/ServerMember.ts
@@ -11,7 +11,7 @@ export class ServerMember extends Base {
 	/** The user the server member belongs to. */
 	public readonly user: User;
 	/** The IDs of roles the server member has. */
-	public readonly roleIds: number[];
+	public roleIds: number[];
 	/** The nickname of the server member. */
 	public nickname?: string;
 	/** The date the member joined the server. */
@@ -72,7 +72,7 @@ export class ServerMember extends Base {
 		await this.server.members.setNickname(this, nickname);
 		return this;
 	}
-	
+
 	/**
 	 * Remove the nickname of the server member.
 	 * @returns The edited server member.

--- a/packages/guilded.ts/src/structures/server/ServerMember.ts
+++ b/packages/guilded.ts/src/structures/server/ServerMember.ts
@@ -13,7 +13,7 @@ export class ServerMember extends Base {
 	/** The IDs of roles the server member has. */
 	public readonly roleIds: number[];
 	/** The nickname of the server member. */
-	public readonly nickname?: string;
+	public nickname?: string;
 	/** The date the member joined the server. */
 	public readonly joinedAt?: Date;
 	/** Whether the server member is the server owner. */
@@ -72,11 +72,7 @@ export class ServerMember extends Base {
 		await this.server.members.setNickname(this, nickname);
 		return this;
 	}
-
-	public updateCacheNickname(raw: WSEvents["TeamMemberUpdated"]): void {
-		(this.nickname as string | undefined) = 'nickname' in raw.userInfo ? raw.userInfo.nickname : undefined;
-	}
-
+	
 	/**
 	 * Remove the nickname of the server member.
 	 * @returns The edited server member.

--- a/packages/guilded.ts/src/structures/server/ServerMember.ts
+++ b/packages/guilded.ts/src/structures/server/ServerMember.ts
@@ -1,4 +1,4 @@
-import { APIServerMember, APIServerMemberSummary, APISocialLink, WSEvents } from 'guilded-api-typings';
+import { APIServerMember, APIServerMemberSummary, APISocialLink } from 'guilded-api-typings';
 import { Base } from '../Base';
 import { Server } from './Server';
 import { User } from '../User';

--- a/packages/guilded.ts/src/ws/events/member.ts
+++ b/packages/guilded.ts/src/ws/events/member.ts
@@ -56,6 +56,6 @@ export async function unbanned(client: Client, data: WSEvents['TeamMemberUnbanne
 export async function updated(client: Client, data: WSEvents['TeamMemberUpdated']) {
 	const server = await client.servers.fetch(data.serverId);
 	const member = await server.members.fetch(data.userInfo.id);
-	member.updateCacheNickname(data)
+	if(data.userInfo.nickname) member.nickname = data.userInfo.nickname
 	client.emit('memberEdit', member);
 }

--- a/packages/guilded.ts/src/ws/events/member.ts
+++ b/packages/guilded.ts/src/ws/events/member.ts
@@ -56,5 +56,6 @@ export async function unbanned(client: Client, data: WSEvents['TeamMemberUnbanne
 export async function updated(client: Client, data: WSEvents['TeamMemberUpdated']) {
 	const server = await client.servers.fetch(data.serverId);
 	const member = await server.members.fetch(data.userInfo.id);
+	member.updateCacheNickname(data)
 	client.emit('memberEdit', member);
 }

--- a/packages/guilded.ts/src/ws/events/server.ts
+++ b/packages/guilded.ts/src/ws/events/server.ts
@@ -8,13 +8,11 @@ import { Client } from '../../structures/Client';
  */
 export async function rolesUpdated(client: Client, data: WSEvents['teamRolesUpdated']) {
 	const server = await client.servers.fetch(data.serverId);
-	for (const item of data.memberRoleIds) {
+	for (const item of data.memberRoleIds)
 		if(item.roleIds) {
 			const member = await server.members.fetch(item.userId)
 			member.roleIds = item.roleIds
 		}
-	}
-
 	client.emit('rolesEdit', server);
 }
  

--- a/packages/guilded.ts/src/ws/events/server.ts
+++ b/packages/guilded.ts/src/ws/events/server.ts
@@ -8,5 +8,13 @@ import { Client } from '../../structures/Client';
  */
 export async function rolesUpdated(client: Client, data: WSEvents['teamRolesUpdated']) {
 	const server = await client.servers.fetch(data.serverId);
+	await Promise.all(data.memberRoleIds.map(async (item) => {
+		if(item.roleIds) {
+			const member = await server.members.fetch(item.userId)
+			member.roleIds = item.roleIds
+		}
+	}))
+
 	client.emit('rolesEdit', server);
 }
+ 

--- a/packages/guilded.ts/src/ws/events/server.ts
+++ b/packages/guilded.ts/src/ws/events/server.ts
@@ -8,12 +8,12 @@ import { Client } from '../../structures/Client';
  */
 export async function rolesUpdated(client: Client, data: WSEvents['teamRolesUpdated']) {
 	const server = await client.servers.fetch(data.serverId);
-	await Promise.all(data.memberRoleIds.map(async (item) => {
+	for (const item of data.memberRoleIds) {
 		if(item.roleIds) {
 			const member = await server.members.fetch(item.userId)
 			member.roleIds = item.roleIds
 		}
-	}))
+	}
 
 	client.emit('rolesEdit', server);
 }


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:
fixed ServerMember(s) not being updated and returning incorrect data from emitted events
events fixed 
- rolesEdit
- memberEdit

this PR addresses issue #17 
## Status

-   [x] Tested - The changes in this PR have been tested and have passed

## Semantic versioning classification

-   [ ] Major - This PR includes breaking changes (Features changed or removed)
-   [ ] Minor - This PR includes backwards compatible changes (Features added)
-   [x] Patch - This PR includes backwards compatible bug fixes or typo fixes (Bugs or Typos fixed)
