### PR TITLE
feat: switch from `glob` to `fast-glob`

### DIFF
--- a/.changeset/perfect-mails-invite.md
+++ b/.changeset/perfect-mails-invite.md
@@ -1,0 +1,5 @@
+---
+'@guildedts/framework': patch
+---
+
+feat: switch from the `glob` module to the `fast-glob` module

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"@guildedts/framework": "workspace:^",
 		"@guildedts/rest": "workspace:^",
 		"@guildedts/ws": "workspace:^",
-		"@types/glob": "^7.2.0",
 		"@types/node": "^18.0.6",
 		"@typescript-eslint/eslint-plugin": "^5.30.7",
 		"@typescript-eslint/parser": "^5.30.7",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -38,7 +38,7 @@
 		"@discordjs/collection": "^1.0.0",
 		"chalk": "^4.1.2",
 		"commander": "^9.4.0",
-		"glob": "^8.0.3",
+		"fast-glob": "^3.2.11",
 		"guilded.ts": "workspace:^",
 		"joi": "^17.6.0",
 		"yaml": "^2.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ importers:
             '@guildedts/framework': workspace:^
             '@guildedts/rest': workspace:^
             '@guildedts/ws': workspace:^
-            '@types/glob': ^7.2.0
             '@types/node': ^18.0.6
             '@typescript-eslint/eslint-plugin': ^5.30.7
             '@typescript-eslint/parser': ^5.30.7
@@ -33,7 +32,6 @@ importers:
             '@guildedts/framework': link:packages/framework
             '@guildedts/rest': link:packages/rest
             '@guildedts/ws': link:packages/ws
-            '@types/glob': 7.2.0
             '@types/node': 18.0.6
             '@typescript-eslint/eslint-plugin': 5.30.7_6wltbjakwuqm7awqswigmiuhd4
             '@typescript-eslint/parser': 5.30.7_he2ccbldppg44uulnyq4rwocfa
@@ -66,7 +64,7 @@ importers:
             '@discordjs/collection': ^1.0.0
             chalk: ^4.1.2
             commander: ^9.4.0
-            glob: ^8.0.3
+            fast-glob: ^3.2.11
             guilded.ts: workspace:^
             joi: ^17.6.0
             rimraf: ^3.0.2
@@ -76,7 +74,7 @@ importers:
             '@discordjs/collection': 1.0.0
             chalk: 4.1.2
             commander: 9.4.0
-            glob: 8.0.3
+            fast-glob: 3.2.11
             guilded.ts: link:../guilded.ts
             joi: 17.6.0
             yaml: 2.1.1
@@ -584,7 +582,6 @@ packages:
         dependencies:
             '@nodelib/fs.stat': 2.0.5
             run-parallel: 1.2.0
-        dev: true
 
     /@nodelib/fs.stat/2.0.5:
         resolution:
@@ -592,7 +589,6 @@ packages:
                 integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
             }
         engines: { node: '>= 8' }
-        dev: true
 
     /@nodelib/fs.walk/1.2.8:
         resolution:
@@ -603,7 +599,6 @@ packages:
         dependencies:
             '@nodelib/fs.scandir': 2.1.5
             fastq: 1.13.0
-        dev: true
 
     /@npmcli/fs/1.1.1:
         resolution:
@@ -705,16 +700,6 @@ packages:
             }
         dev: true
 
-    /@types/glob/7.2.0:
-        resolution:
-            {
-                integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==,
-            }
-        dependencies:
-            '@types/minimatch': 3.0.5
-            '@types/node': 18.0.6
-        dev: true
-
     /@types/is-ci/3.0.0:
         resolution:
             {
@@ -728,13 +713,6 @@ packages:
         resolution:
             {
                 integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==,
-            }
-        dev: true
-
-    /@types/minimatch/3.0.5:
-        resolution:
-            {
-                integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==,
             }
         dev: true
 
@@ -1151,6 +1129,7 @@ packages:
             {
                 integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
             }
+        dev: true
 
     /better-path-resolve/1.0.0:
         resolution:
@@ -1179,6 +1158,7 @@ packages:
             }
         dependencies:
             balanced-match: 1.0.2
+        dev: true
 
     /braces/3.0.2:
         resolution:
@@ -1188,7 +1168,6 @@ packages:
         engines: { node: '>=8' }
         dependencies:
             fill-range: 7.0.1
-        dev: true
 
     /breakword/1.0.5:
         resolution:
@@ -2038,7 +2017,6 @@ packages:
             glob-parent: 5.1.2
             merge2: 1.4.1
             micromatch: 4.0.5
-        dev: true
 
     /fast-json-stable-stringify/2.1.0:
         resolution:
@@ -2061,7 +2039,6 @@ packages:
             }
         dependencies:
             reusify: 1.0.4
-        dev: true
 
     /file-entry-cache/6.0.1:
         resolution:
@@ -2081,7 +2058,6 @@ packages:
         engines: { node: '>=8' }
         dependencies:
             to-regex-range: 5.0.1
-        dev: true
 
     /find-up/4.1.0:
         resolution:
@@ -2184,6 +2160,7 @@ packages:
             {
                 integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==,
             }
+        dev: true
 
     /function-bind/1.1.1:
         resolution:
@@ -2265,7 +2242,6 @@ packages:
         engines: { node: '>= 6' }
         dependencies:
             is-glob: 4.0.3
-        dev: true
 
     /glob-parent/6.0.2:
         resolution:
@@ -2290,20 +2266,6 @@ packages:
             once: 1.4.0
             path-is-absolute: 1.0.1
         dev: true
-
-    /glob/8.0.3:
-        resolution:
-            {
-                integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==,
-            }
-        engines: { node: '>=12' }
-        dependencies:
-            fs.realpath: 1.0.0
-            inflight: 1.0.6
-            inherits: 2.0.4
-            minimatch: 5.1.0
-            once: 1.4.0
-        dev: false
 
     /globals/13.17.0:
         resolution:
@@ -2566,12 +2528,14 @@ packages:
         dependencies:
             once: 1.4.0
             wrappy: 1.0.2
+        dev: true
 
     /inherits/2.0.4:
         resolution:
             {
                 integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
             }
+        dev: true
 
     /internal-slot/1.0.3:
         resolution:
@@ -2662,7 +2626,6 @@ packages:
                 integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
             }
         engines: { node: '>=0.10.0' }
-        dev: true
 
     /is-fullwidth-code-point/3.0.0:
         resolution:
@@ -2688,7 +2651,6 @@ packages:
         engines: { node: '>=0.10.0' }
         dependencies:
             is-extglob: 2.1.1
-        dev: true
 
     /is-lambda/1.0.1:
         resolution:
@@ -2721,7 +2683,6 @@ packages:
                 integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
             }
         engines: { node: '>=0.12.0' }
-        dev: true
 
     /is-plain-obj/1.1.0:
         resolution:
@@ -3169,7 +3130,6 @@ packages:
                 integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
             }
         engines: { node: '>= 8' }
-        dev: true
 
     /micromatch/4.0.5:
         resolution:
@@ -3180,7 +3140,6 @@ packages:
         dependencies:
             braces: 3.0.2
             picomatch: 2.3.1
-        dev: true
 
     /mime-db/1.52.0:
         resolution:
@@ -3241,6 +3200,7 @@ packages:
         engines: { node: '>=10' }
         dependencies:
             brace-expansion: 2.0.1
+        dev: true
 
     /minimist-options/4.1.0:
         resolution:
@@ -3487,6 +3447,7 @@ packages:
             }
         dependencies:
             wrappy: 1.0.2
+        dev: true
 
     /onetime/5.1.2:
         resolution:
@@ -3690,7 +3651,6 @@ packages:
                 integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
             }
         engines: { node: '>=8.6' }
-        dev: true
 
     /pidtree/0.6.0:
         resolution:
@@ -3811,7 +3771,6 @@ packages:
             {
                 integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
             }
-        dev: true
 
     /quick-lru/4.0.1:
         resolution:
@@ -3965,7 +3924,6 @@ packages:
                 integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==,
             }
         engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
-        dev: true
 
     /rfdc/1.3.0:
         resolution:
@@ -3991,7 +3949,6 @@ packages:
             }
         dependencies:
             queue-microtask: 1.2.3
-        dev: true
 
     /rxjs/7.5.6:
         resolution:
@@ -4452,7 +4409,6 @@ packages:
         engines: { node: '>=8.0' }
         dependencies:
             is-number: 7.0.0
-        dev: true
 
     /tr46/0.0.3:
         resolution:
@@ -4840,6 +4796,7 @@ packages:
             {
                 integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
             }
+        dev: true
 
     /ws/8.8.1:
         resolution:


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:

Switch from the the [glob](https://npmjs.org/glob) module to the [fast-glob](https://npmjs.org/fast-glob) module for matching glob patterns.

## Status

-   [x] Tested - The changes in this PR have been tested and have passed

## Semantic versioning classification

-   [ ] Major - This PR includes breaking changes (Features changed or removed)
-   [ ] Minor - This PR includes backwards compatible changes (Features added)
-   [x] Patch - This PR includes backwards compatible bug fixes or typo fixes (Bugs or Typos fixed)
