### PR TITLE
feat: forum topic pinning

### DIFF
--- a/.changeset/fresh-tomatoes-brush.md
+++ b/.changeset/fresh-tomatoes-brush.md
@@ -1,0 +1,5 @@
+---
+'guilded.ts': patch
+---
+
+fix: unrecognised events throw error

--- a/.changeset/seven-comics-retire.md
+++ b/.changeset/seven-comics-retire.md
@@ -1,0 +1,7 @@
+---
+'guilded-api-typings': minor
+'guilded.ts': minor
+'@guildedts/rest': minor
+---
+
+feat: forum topic pinning

--- a/packages/guilded-api-typings/src/v1/REST.ts
+++ b/packages/guilded-api-typings/src/v1/REST.ts
@@ -139,14 +139,32 @@ export class Routes {
 	/**
 	 * The endpoint for a forum topic.
 	 * @param channelId The ID of the channel the forum topic belongs to.
-	 * @param topicId The ID of the forum topic.
+	 * @param forumTopicId The ID of the forum topic.
 	 * @see https://www.guilded.gg/docs/api/forums/ForumTopicRead
 	 * @see https://www.guilded.gg/docs/api/forums/ForumTopicUpdate
 	 * @see https://www.guilded.gg/docs/api/forums/ForumTopicDelete
 	 * @example Routes.forumTopic('abc', 123); // '/channels/abc/topics/123'
 	 */
-	static forumTopic(channelId: string, topicId: number): `/channels/${string}/topics/${number}` {
-		return `/channels/${channelId}/topics/${topicId}`;
+	static forumTopic(
+		channelId: string,
+		forumTopicId: number,
+	): `/channels/${string}/topics/${number}` {
+		return `/channels/${channelId}/topics/${forumTopicId}`;
+	}
+
+	/**
+	 * The endpoint for a forum topic pin.
+	 * @param channelId The ID of the channel the forum topic belongs to.
+	 * @param forumTopicId The ID of the forum topic.
+	 * @see https://www.guilded.gg/docs/api/forums/ForumTopicPin
+	 * @see https://www.guilded.gg/docs/api/forums/ForumTopicUnpin
+	 * @example Routes.forumTopicPin('abc', 123); // '/channels/abc/topics/123/pin'
+	 */
+	static forumTopicPin(
+		channelId: string,
+		forumTopicId: number,
+	): `/channels/${string}/topics/${number}/pin` {
+		return `/channels/${channelId}/topics/${forumTopicId}/pin`;
 	}
 
 	/**

--- a/packages/guilded-api-typings/src/v1/WS.ts
+++ b/packages/guilded-api-typings/src/v1/WS.ts
@@ -290,6 +290,26 @@ export interface WSEvents {
 		forumTopic: APIForumTopic;
 	};
 	/**
+	 * Emitted when a forum topic is pinned.
+	 * @see https://www.guilded.gg/docs/api/websockets/ForumTopicPinned
+	 */
+	ForumTopicPinned: {
+		/** The ID of the server the forum topic belongs to. */
+		serverId: string;
+		/** The pinned forum topic. */
+		forumTopic: APIForumTopic;
+	};
+	/**
+	 * Emitted when a forum topic is unpinned.
+	 * @see https://www.guilded.gg/docs/api/websockets/ForumTopicUnpinned
+	 */
+	ForumTopicUnpinned: {
+		/** The ID of the server the forum topic belongs to. */
+		serverId: string;
+		/** The unpinned forum topic. */
+		forumTopic: APIForumTopic;
+	};
+	/**
 	 * Emitted when a calendar event RSVP is edited.
 	 * @see https://www.guilded.gg/docs/api/websockets/CalendarEventRsvpUpdated
 	 */

--- a/packages/guilded.ts/src/managers/ForumTopicManager.ts
+++ b/packages/guilded.ts/src/managers/ForumTopicManager.ts
@@ -92,6 +92,26 @@ export class ForumTopicManager extends BaseManager<number, ForumTopic> {
 		forumTopic = forumTopic instanceof ForumTopic ? forumTopic.id : forumTopic;
 		return this.client.api.forumTopics.delete(this.channel.id, forumTopic);
 	}
+
+	/**
+	 * Pin a forum topic in the channel.
+	 * @param forumTopic The forum topic to pin.
+	 * @example topics.pin(forumTopic);
+	 */
+	pin(forumTopic: number | ForumTopic) {
+		forumTopic = forumTopic instanceof ForumTopic ? forumTopic.id : forumTopic;
+		return this.client.api.forumTopics.pin(this.channel.id, forumTopic);
+	}
+
+	/**
+	 * Unpin a forum topic from the channel.
+	 * @param forumTopic The forum topic to unpin.
+	 * @example topics.unpin(forumTopic);
+	 */
+	unpin(forumTopic: number | ForumTopic) {
+		forumTopic = forumTopic instanceof ForumTopic ? forumTopic.id : forumTopic;
+		return this.client.api.forumTopics.unpin(this.channel.id, forumTopic);
+	}
 }
 
 /** The options for fetching forum topics. */

--- a/packages/guilded.ts/src/structures/Client.ts
+++ b/packages/guilded.ts/src/structures/Client.ts
@@ -238,6 +238,10 @@ export interface ClientEvents {
 	forumTopicEdit: [newForumTopic: ForumTopic, oldForumTopic?: ForumTopic];
 	/** Emitted when a forum topic is deleted. */
 	forumTopicDelete: [forumTopic: ForumTopic];
+	/** Emitted when a forum topic is pinned. */
+	forumTopicPin: [forumTopic: ForumTopic];
+	/** Emitted when a forum topic is unpinned. */
+	forumTopicUnpin: [forumTopic: ForumTopic];
 	/** Emitted when a calendar event RSVP is edited. */
 	calendarEventRsvpEdit: [
 		newCalendarEventRsvp: CalendarEventRsvp,

--- a/packages/guilded.ts/src/structures/ForumTopic.ts
+++ b/packages/guilded.ts/src/structures/ForumTopic.ts
@@ -159,7 +159,27 @@ export class ForumTopic extends Base<number> {
 	 * @example forumTopic.delete();
 	 */
 	async delete() {
-		this.channel.topics.delete(this);
+		await this.channel.topics.delete(this);
+		return this;
+	}
+
+	/**
+	 * Pin the forum topic.
+	 * @returns The pinned forum topic.
+	 * @example forumTopic.pin();
+	 */
+	async pin() {
+		await this.channel.topics.pin(this);
+		return this;
+	}
+
+	/**
+	 * Unpin the forum topic.
+	 * @returns The unpinned forum topic.
+	 * @example forumTopic.unpin();
+	 */
+	async unpin() {
+		await this.channel.topics.unpin(this);
 		return this;
 	}
 }

--- a/packages/guilded.ts/src/ws/events/forumTopic.ts
+++ b/packages/guilded.ts/src/ws/events/forumTopic.ts
@@ -37,3 +37,25 @@ export async function deleted(client: Client, data: WSEvents['ForumTopicDeleted'
 	if (client.options.disposeCachedForumTopics ?? true) channel.topics.cache.delete(forumTopic.id);
 	client.emit('forumTopicDelete', forumTopic);
 }
+
+/**
+ * Handle the ForumTopicPinned event.
+ * @param client The client the Websocket belongs to.
+ * @param data The data of the event.
+ */
+export async function pinned(client: Client, data: WSEvents['ForumTopicPinned']) {
+	const channel = (await client.channels.fetch(data.forumTopic.channelId)) as ForumChannel;
+	const forumTopic = new ForumTopic(channel, data.forumTopic);
+	client.emit('forumTopicPin', forumTopic);
+}
+
+/**
+ * Handle the ForumTopicUnpinned event.
+ * @param client The client the Websocket belongs to.
+ * @param data The data of the event.
+ */
+export async function unpinned(client: Client, data: WSEvents['ForumTopicUnpinned']) {
+	const channel = (await client.channels.fetch(data.forumTopic.channelId)) as ForumChannel;
+	const forumTopic = new ForumTopic(channel, data.forumTopic);
+	client.emit('forumTopicUnpin', forumTopic);
+}

--- a/packages/guilded.ts/src/ws/index.ts
+++ b/packages/guilded.ts/src/ws/index.ts
@@ -60,5 +60,5 @@ export function handleWSEvent(
 	event: keyof WSEvents,
 	data: WSEvents[keyof WSEvents],
 ) {
-	return WSEventHandler[event](client, data as any);
+	return WSEventHandler[event]?.(client, data as any);
 }

--- a/packages/guilded.ts/src/ws/index.ts
+++ b/packages/guilded.ts/src/ws/index.ts
@@ -37,6 +37,8 @@ const WSEventHandler: {
 	ForumTopicCreated: forumTopic.created,
 	ForumTopicUpdated: forumTopic.updated,
 	ForumTopicDeleted: forumTopic.deleted,
+	ForumTopicPinned: forumTopic.pinned,
+	ForumTopicUnpinned: forumTopic.unpinned,
 	CalendarEventRsvpUpdated: calendarEvent.rsvpUpdated,
 	CalendarEventRsvpManyUpdated: calendarEvent.rsvpsUpdated,
 	CalendarEventRsvpDeleted: calendarEvent.rsvpDeleted,

--- a/packages/rest/src/routers/ForumTopicRouter.ts
+++ b/packages/rest/src/routers/ForumTopicRouter.ts
@@ -95,4 +95,24 @@ export class ForumTopicRouter extends BaseRouter {
 	delete(channelId: string, forumTopicId: number) {
 		return this.rest.delete<void>(Routes.forumTopic(channelId, forumTopicId));
 	}
+
+	/**
+	 * Pin a forum topic on Guilded.
+	 * @param channelId The ID of the channel the forum topic belongs to.
+	 * @param forumTopicId The ID of the forum topic to pin.
+	 * @example topics.pin('abc', 123);
+	 */
+	pin(channelId: string, forumTopicId: number) {
+		return this.rest.put<void>(Routes.forumTopicPin(channelId, forumTopicId));
+	}
+
+	/**
+	 * Unpin a forum topic on Guilded.
+	 * @param channelId The ID of the channel the forum topic belongs to.
+	 * @param forumTopicId The ID of the forum topic to unpin.
+	 * @example topics.unpin('abc', 123);
+	 */
+	unpin(channelId: string, forumTopicId: number) {
+		return this.rest.delete<void>(Routes.forumTopicPin(channelId, forumTopicId));
+	}
 }


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:

Added forum topic pinning and unpinning support with its ws events.
This pr also includes a patch which fixes a bug where the event handler throws events for unrecognised ws events.

## Status

-   [x] Tested - The changes in this PR have been tested and have passed

## Semantic versioning classification

-   [ ] Major - This PR includes breaking changes (Features changed or removed)
-   [x] Minor - This PR includes backwards compatible changes (Features added)
-   [ ] Patch - This PR includes backwards compatible bug fixes or typo fixes (Bugs or Typos fixed)
