### PR TITLE
feat: webhook `uername` and `avatar_url` support

### DIFF
--- a/.changeset/fifty-kings-buy.md
+++ b/.changeset/fifty-kings-buy.md
@@ -1,0 +1,7 @@
+---
+'guilded-api-typings': minor
+'guilded.ts': minor
+'@guildedts/rest': minor
+---
+
+feat: webhook `username` and `avatar_url` support

--- a/.changeset/late-pens-allow.md
+++ b/.changeset/late-pens-allow.md
@@ -1,0 +1,5 @@
+---
+'@guildedts/rest': minor
+---
+
+feat(RESTOptions): add `proxyUrl`

--- a/packages/guilded-api-typings/src/v1/REST.ts
+++ b/packages/guilded-api-typings/src/v1/REST.ts
@@ -410,4 +410,17 @@ export class Routes {
 	static webhook(serverId: string, webhookId: string): `/servers/${string}/webhooks/${string}` {
 		return `/servers/${serverId}/webhooks/${webhookId}`;
 	}
+
+	/**
+	 * The endpoint for a webhook execution on Guilded.
+	 * @param webhookId The ID of the webhook.
+	 * @param webhookToken The ID of the webhook.
+	 * @example Routes.webhookExecute('abc', 'abc'); // '/webhooks/abc/abc'
+	 */
+	static webhookExecute(
+		webhookId: string,
+		webhookToken: string,
+	): `/webhooks/${string}/${string}` {
+		return `/webhooks/${webhookId}/${webhookToken}`;
+	}
 }

--- a/packages/guilded-api-typings/src/v1/structures/Webhook.ts
+++ b/packages/guilded-api-typings/src/v1/structures/Webhook.ts
@@ -1,3 +1,6 @@
+import { APIEmbed } from './Embed';
+import { APIMessageEditPayload } from './Message';
+
 /**
  * Represents a webhook on Guilded.
  * @see https://www.guilded.gg/docs/api/webhook/Webhook
@@ -29,6 +32,20 @@ export interface APIWebhookPayload extends APIWebhookEditPayload {
 	/** The ID of the channel the webhook belongs to. */
 	channelId: string;
 }
+
+/**
+ * The payload for creating a webhook message.
+ * @see https://guildedapi.com/resources/webhook/#execute-webhook
+ */
+export interface APIWebhookMessagePayload extends APIMessageEditPayload {
+	/** The name of the webhook. */
+	username?: string;
+	/** The avatar URL of the webhook. */
+	avatar_url?: string;
+}
+
+/** The resolvable payload for creating a webhook message. */
+export type APIWebhookMessagePayloadResolvable = string | APIEmbed[] | APIWebhookMessagePayload;
 
 /**
  * The payload for editing a webhook.

--- a/packages/guilded.ts/package.json
+++ b/packages/guilded.ts/package.json
@@ -34,11 +34,9 @@
 		"@guildedts/builders": "workspace:^",
 		"@guildedts/rest": "workspace:^",
 		"@guildedts/ws": "workspace:^",
-		"guilded-api-typings": "workspace:^",
-		"node-fetch": "^2.6.7"
+		"guilded-api-typings": "workspace:^"
 	},
 	"devDependencies": {
-		"@types/node-fetch": "^2.6.2",
 		"rimraf": "^3.0.2",
 		"typescript": "^4.7.4"
 	}

--- a/packages/guilded.ts/src/managers/channel/ChannelWebhookManager.ts
+++ b/packages/guilded.ts/src/managers/channel/ChannelWebhookManager.ts
@@ -2,6 +2,8 @@ import { BaseManager, FetchManyOptions, FetchOptions } from '../BaseManager';
 import { Channel } from '../../structures/channel/Channel';
 import { Webhook } from '../../structures/Webhook';
 import { Collection } from '@discordjs/collection';
+import { APIEmbed, APIWebhookMessagePayload } from 'guilded-api-typings';
+import { Embed } from '@guildedts/builders';
 
 /**
  * The manager of webhooks that belong to a channel.
@@ -101,3 +103,12 @@ export class ChannelWebhookManager extends BaseManager<string, Webhook> {
 		return this.client.api.webhooks.delete(this.channel.serverId, webhook);
 	}
 }
+
+/** The payload for creating a webhook message. */
+export interface WebhookMessagePayload extends Omit<APIWebhookMessagePayload, 'embeds'> {
+	/** The embeds of the message. */
+	embeds?: (Embed | APIEmbed)[];
+}
+
+/** The resolvable payload for creating a webhook message. */
+export type WebhookMessagePayloadResolvable = string | (Embed | APIEmbed)[] | WebhookMessagePayload;

--- a/packages/guilded.ts/src/structures/Webhook.ts
+++ b/packages/guilded.ts/src/structures/Webhook.ts
@@ -1,9 +1,8 @@
-import { APIEmbed, APIWebhook } from 'guilded-api-typings';
-import { Embed } from '@guildedts/builders';
-import fetch from 'node-fetch';
+import { APIWebhook } from 'guilded-api-typings';
 import { Base } from './Base';
 import { FetchOptions } from '../managers/BaseManager';
 import { Channel } from './channel/Channel';
+import { WebhookMessagePayloadResolvable } from '../managers/channel/ChannelWebhookManager';
 
 /**
  * Represents a webhook on Guilded.
@@ -112,23 +111,8 @@ export class Webhook extends Base {
 	 * @param payload The payload of the message.
 	 * @example webhook.send('Hello world!');
 	 */
-	async send(
-		payload:
-			| string
-			| (Embed | APIEmbed)[]
-			| { content?: string; embeds?: (Embed | APIEmbed)[] },
-	) {
-		await fetch(`https://media.guilded.gg/webhooks/${this.id}/${this.token}`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(
-				typeof payload === 'string'
-					? { content: payload }
-					: Array.isArray(payload)
-					? { embeds: payload }
-					: payload,
-			),
-		});
+	send(payload: WebhookMessagePayloadResolvable) {
+		return this.client.api.webhooks.send(this.id, this.token!, payload);
 	}
 
 	/**

--- a/packages/rest/src/RESTManager.ts
+++ b/packages/rest/src/RESTManager.ts
@@ -14,20 +14,24 @@ export class RESTManager extends EventEmitter {
 	/** The auth token for the REST API. */
 	token?: string;
 	/** The version of the REST API. */
-	readonly version: number;
+	readonly version?: number;
+	/** The proxy url of the REST API. */
+	readonly proxyUrl?: string;
 	/** The router for the REST API. */
-	readonly router = new Router(this);
+	readonly router: Router;
 
 	/** @param options The options for the REST manager. */
 	constructor(public readonly options: RESTOptions) {
 		super();
 		this.token = options.token;
-		this.version = options.version;
+		this.proxyUrl = options.proxyUrl;
+		if (!this.proxyUrl) this.version = options.version;
+		this.router = new Router(this);
 	}
 
 	/** The base URL for the REST API. */
-	get baseURL(): `https://www.guilded.gg/api/v${number}/` {
-		return `https://www.guilded.gg/api/v${this.version}/`;
+	get baseURL() {
+		return this.proxyUrl ? this.proxyUrl : `https://www.guilded.gg/api/v${this.version}/`;
 	}
 
 	/**
@@ -64,7 +68,7 @@ export class RESTManager extends EventEmitter {
 			method,
 			headers: {
 				'Content-Type': 'application/json',
-				Authorization: `Bearer ${this.token}`,
+				...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
 				'User-Agent': `@guildedts/rest@${version} Node.JS@${process.versions.node}`,
 			},
 			body: options.body ? JSON.stringify(options.body) : undefined,
@@ -183,7 +187,9 @@ export interface RESTOptions {
 	/** The auth token for the REST API. */
 	token?: string;
 	/** The version of the REST API. */
-	version: number;
+	version?: number;
+	/** The proxy URL of the REST API. */
+	proxyUrl?: string;
 	/** The interval to wait between retries. */
 	retryInterval?: number;
 	/** The maximum number of retry attempts. */

--- a/packages/rest/src/routers/WebhookRouter.ts
+++ b/packages/rest/src/routers/WebhookRouter.ts
@@ -2,10 +2,12 @@ import {
 	APIhWebhookFetchManyOptions,
 	APIWebhook,
 	APIWebhookEditPayload,
+	APIWebhookMessagePayloadResolvable,
 	APIWebhookPayload,
 	Routes,
 } from 'guilded-api-typings';
 import { BaseRouter } from './BaseRouter';
+import fetch from 'node-fetch';
 
 /**
  * The webhook router for the Guilded REST API.
@@ -39,6 +41,31 @@ export class WebhookRouter extends BaseRouter {
 			APIhWebhookFetchManyOptions
 		>(Routes.webhooks(serverId), { channelId });
 		return webhooks;
+	}
+
+	/**
+	 * Create a webhook message on Guilded.
+	 * @param webhookId The ID of the webhook.
+	 * @param webhookToken The token of the webhook.
+	 * @param payload The payload of the message.
+	 * @example webhooks.send('abc', 'abc', 'Hello world!');
+	 */
+	async send(
+		webhookId: string,
+		webhookToken: string,
+		payload: APIWebhookMessagePayloadResolvable,
+	) {
+		await fetch(`https://media.guilded.gg${Routes.webhookExecute(webhookId, webhookToken)}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(
+				typeof payload === 'string'
+					? { content: payload }
+					: Array.isArray(payload)
+					? { embeds: payload }
+					: payload,
+			),
+		});
 	}
 
 	/**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,9 +97,7 @@ importers:
             '@guildedts/builders': workspace:^
             '@guildedts/rest': workspace:^
             '@guildedts/ws': workspace:^
-            '@types/node-fetch': ^2.6.2
             guilded-api-typings: workspace:^
-            node-fetch: ^2.6.7
             rimraf: ^3.0.2
             typescript: ^4.7.4
         dependencies:
@@ -108,9 +106,7 @@ importers:
             '@guildedts/rest': link:../rest
             '@guildedts/ws': link:../ws
             guilded-api-typings: link:../guilded-api-typings
-            node-fetch: 2.6.7
         devDependencies:
-            '@types/node-fetch': 2.6.2
             rimraf: 3.0.2
             typescript: 4.7.4
 


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:

Added support for `username` and `avatar_url` properties when creating a webhook message.

Also added `proxyUrl` to `RESTOptions`

## Status

-   [x] Tested - The changes in this PR have been tested and have passed

## Semantic versioning classification

-   [ ] Major - This PR includes breaking changes (Features changed or removed)
-   [x] Minor - This PR includes backwards compatible changes (Features added)
-   [ ] Patch - This PR includes backwards compatible bug fixes or typo fixes (Bugs or Typos fixed)
