### PR TITLE
feat: add `idle` to collector options

### DIFF
--- a/.changeset/sour-toys-refuse.md
+++ b/.changeset/sour-toys-refuse.md
@@ -1,0 +1,5 @@
+---
+'guilded.ts': minor
+---
+
+feat: add `idle` to collector options


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged:

Add `idle` option in collectors which is a timeout for an idle collector.

## Status

-   [x] Tested - The changes in this PR have been tested and have passed

## Semantic versioning classification

-   [ ] Major - This PR includes breaking changes (Features changed or removed)
-   [x] Minor - This PR includes backwards compatible changes (Features added)
-   [ ] Patch - This PR includes backwards compatible bug fixes or typo fixes (Bugs or Typos fixed)
